### PR TITLE
Feat: Ensure directories exist before copying files

### DIFF
--- a/src/linux_arctis_manager/scripts/cli.py
+++ b/src/linux_arctis_manager/scripts/cli.py
@@ -144,6 +144,7 @@ def write_desktop_entries() -> int:
     shutil.copyfile(Path(__file__).parent.parent / 'gui' / 'images' / 'steelseries_logo.svg', ICON_PATH)
 
     # 2. write the desktop entries
+    DESKTOP_WINDOW_PATH.parent.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(Path(__file__).parent.parent / 'desktop' / 'ArctisManager.desktop', DESKTOP_WINDOW_PATH)
     shutil.copyfile(Path(__file__).parent.parent / 'desktop' / 'ArctisManagerSystray.desktop', DESKTOP_SYSTRAY_PATH)
 


### PR DESCRIPTION
## Summary:
Prevents `FileNotFoundError` when running `lam-cli desktop write` on fresh Linux installations where the user-level applications directory hasn't been created yet.

## Changes:
Added a recursive directory creation check (`mkdir -p` equivalent) for the parent directory of `DESKTOP_WINDOW_PATH` and `DESKTOP_SYSTRAY_PATH`.

Ensures that `~/.local/share/applications/` exists before `shutil.copyfile` attempts to write the .desktop entries.