### PR TITLE
Feature/arctis 7 plus support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Fixed
+
+- `CoreEngine.device_settings` is no longer uninitialized when no recognized device is connected; `lam-gui` no longer crashes with `AttributeError` in that scenario (fixes [#27](https://github.com/elegos/Linux-Arctis-Manager/issues/27))
+
 ## [2.3.1]
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An open-source replacement for SteelSeries GG, to manage your Arctis headset on 
 | Arctis Nova 5 | ➖ | ✅ | `2232`, `2253` |
 | Arctis Nova 7 / 7X / Diablo IV / Gen 2 (% battery) | ✅ | ✅ | `22a1`, `227e`, `2258`, `229e`, `22a9`, `22a5` |
 | Arctis Nova 7 / 7X / Diablo IV / Gen 2 (discrete battery) | ✅ | ✅ | `2202`, `2206`, `223a`, `227a`, `22a4` |
-| Arctis Nova 7+ / PS5 / Xbox / Destiny | ❌ | ❌ | `220e`, `2212`, `2216`, `2236` |
+| Arctis Nova 7+ / PS5 / Xbox / Destiny | ✅ | ✅ | `220e`, `2212`, `2216`, `2236` |
 | Arctis Nova 7P | ❌ | ❌ | `220a` |
 | Arctis Nova Elite | ❌ | ❌ | ❓ |
 | Arctis Nova Pro Wireless / X | ✅ | ✅ | `12e0`, `12e5` |

--- a/src/linux_arctis_manager/core.py
+++ b/src/linux_arctis_manager/core.py
@@ -34,7 +34,7 @@ class CoreEngine:
     device_config: DeviceConfiguration | None = None
     usb_device: TypedDevice | None = None
     general_settings: GeneralSettings
-    device_settings: DeviceSettings
+    device_settings: DeviceSettings | None = None
 
     device_status: ObservableDict[str, int]|None = None
 

--- a/src/linux_arctis_manager/core.py
+++ b/src/linux_arctis_manager/core.py
@@ -164,6 +164,11 @@ class CoreEngine:
                 _retry = True
                 self.logger.warning("USB I/O error (errno %d), tearing down device for reset...", e.errno)
                 self.teardown()
+                await asyncio.sleep(2.0)
+                self.configure_virtual_sinks()
+                if self.usb_device is None:
+                    self.logger.error("Device did not recover after USB I/O error (errno %d), exiting for systemd restart", e.errno)
+                    sys.exit(1)
 
     def on_device_connected(self, vendor_id: int, product_id: int) -> None:
         for device_config in self.device_configurations:

--- a/src/linux_arctis_manager/devices/arctis_7_plus.yaml
+++ b/src/linux_arctis_manager/devices/arctis_7_plus.yaml
@@ -1,0 +1,104 @@
+device:
+  name: SteelSeries Arctis 7+
+  vendor_id: 0x1038
+  product_ids:
+    - 0x220e
+    - 0x2212
+    - 0x2216
+    - 0x2236
+  command_padding:
+    length: 64
+    position: end
+    filler: 0x00
+
+  command_interface_index: [0, 3]
+  listen_interface_indexes: [3]
+
+  device_init:
+    - ['status.request']
+    - [0x00, 0xa3, 'settings.pm_shutdown']
+    - [0x00, 0x39, 'settings.mic_side_tone']
+
+  status:
+    request: 0xb0
+    response_mapping:
+      - starts_with: 0xb0
+        headset_power_status: 0x01
+        headset_battery_charge: 0x02
+        cable_charging: 0x03
+        media_mix: 0x04
+        chat_mix: 0x05
+
+    representation:
+      headset:
+        - headset_power_status
+        - headset_battery_charge
+        - cable_charging
+        - chat_mix
+        - media_mix
+      power_management:
+        - pm_shutdown
+      mic:
+        - mic_side_tone
+  
+  online_status:
+    status_variable: headset_power_status
+    online_value: 'on'
+
+  settings:
+    microphone:
+      mic_side_tone:
+        type: discrete_map
+        values_mapping:
+          0x00: off
+          0x01: low
+          0x02: medium  
+          0x03: high
+        default: 0x00 # off
+        update_sequence: [0x00, 0x39, 'value']
+    power_management:
+      pm_shutdown:
+        type: discrete_map
+        values_mapping:
+          0x00: never
+          0x01: 1_minute
+          0x05: 5_minutes
+          0x0a: 10_minutes
+          0x0f: 15_minutes
+          0x1e: 30_minutes
+          0x2d: 45_minutes
+          0x3c: 60_minutes
+          0x4b: 75_minutes
+          0x5a: 90_minutes  
+        default: 0x1e # 30 minutes
+        update_sequence: [0x00, 0xa3, 'value']
+
+  status_parse:
+    headset_power_status:
+      type: int_str_mapping
+      values:
+        0x01: 'off'
+        0x00: 'on'
+        0x02: 'on'
+        0x03: 'on'
+    headset_battery_charge:
+      type: int_int_mapping
+      values:
+        0x00: 0
+        0x01: 25
+        0x02: 50
+        0x03: 75
+        0x04: 100
+    cable_charging:
+      type: int_str_mapping
+      values:
+        0x01: on
+        0x00: off
+    media_mix:
+      type: percentage
+      perc_min: 0
+      perc_max: 100
+    chat_mix:
+      type: percentage
+      perc_min: 0
+      perc_max: 100


### PR DESCRIPTION
Added device config for Arctis 7+ based on HeadsetControl's protocol. Sidetone, battery and chatmix mapped.