### PR TITLE
feat(devices): add support for Arctis Nova 7 World of Warcraft Edition 22ab HID

### DIFF
--- a/src/linux_arctis_manager/devices/nova_7_wireless_discrete_battery.yaml
+++ b/src/linux_arctis_manager/devices/nova_7_wireless_discrete_battery.yaml
@@ -3,10 +3,11 @@ device:
   vendor_id: 0x1038
   product_ids:
     - 0x2202 # Arctis Nova 7
-    - 0x2206 # Arctis Nova 7x
+    - 0x2206 # Arctis Nova 7X
+    - 0x22a4 # Arctis Nova 7X
     - 0x223a # Arctis Nova 7 Diablo IV
     - 0x227a # Arctis Nova 7 WoW Edition
-    - 0x22a4 # Arctis Nova 7X
+    - 0x22ab # Arctis Nova 7 WoW Edition
   command_padding:
     length: 64
     position: end


### PR DESCRIPTION
# Description
Adds support for the `22ab` HID variant of the Arctis Nova 7 World of Warcraft Edition. While the WoW Edition is already in the codebase, this specific hardware revision was not being picked up by the current device matching logic. Thanks to skizzo8909 for sharing and testing this.

## Changes
* **Device Discovery:** Added `0x22ab` to the Nova 7 product ID table.
* **Cleanup:** Reordered list so that matching device variants are grouped