### PR TITLE
feat(devices): add support for Arctis Nova Pro wired 12cb HID

### DIFF
--- a/src/linux_arctis_manager/devices/nova_pro_wired.yaml
+++ b/src/linux_arctis_manager/devices/nova_pro_wired.yaml
@@ -3,6 +3,7 @@ device:
   vendor_id: 0x1038
   product_ids:
     - 0x12cd # Arctis Nova Pro wired / GameDAC Gen 2
+    - 0x12cb # Arctis Nova Pro wired / GameDAC Gen 2
   command_padding:
     length: 64
     position: end


### PR DESCRIPTION
# Description
Adds support for the `12cb` HID variant of the Arctis Nova Pro wired.

## Changes
* **Device Discovery:** Added `0x12cb` to the Nova Pro wired product ID table.