### PR TITLE
feat(setup): add install.sh for single command setup/update

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,52 +6,34 @@ set -e
 
 echo "Installing Linux Arctis Manager..."
 
-IS_ARCH=false
-
-# Check for Arch-based systems first
-if command -v yay &> /dev/null; then
-    echo "Detected yay - Installing/upgrading from AUR..."
-    yay -S --noconfirm linux-arctis-manager
-    IS_ARCH=true
-elif command -v paru &> /dev/null; then
-    echo "Detected paru - Installing/upgrading from AUR..."
-    paru -S --noconfirm linux-arctis-manager
-    IS_ARCH=true
-elif command -v pacman &> /dev/null; then
-    echo "Error: Arch detected but no AUR helper (yay/paru) found. Please install one first."
+# Check if pipx is installed
+if ! command -v pipx &> /dev/null; then
+    echo "Error: pipx not found. Please install pipx first."
     exit 1
-else
-    # Check if pipx is installed
-    if ! command -v pipx &> /dev/null; then
-        echo "Error: pipx not found. Please install pipx first."
-        exit 1
-    fi
-    
-    echo "Fetching latest release..."
-    DOWNLOAD_URL=$(curl -s https://api.github.com/repos/elegos/Linux-Arctis-Manager/releases/latest | grep -oP '"browser_download_url": "\K[^"]*\.whl' | head -1)
-    
-    if [ -z "$DOWNLOAD_URL" ]; then
-        echo "Error: Could not fetch latest release"
-        exit 1
-    fi
-    
-    curl -LO "$DOWNLOAD_URL"
-    WHEEL_FILE=$(basename "$DOWNLOAD_URL")
-    
-    # Check if already installed
-    if pipx list | grep -q "linux-arctis-manager"; then
-        echo "Upgrading existing installation..."
-        pipx install --force "$WHEEL_FILE"
-    else
-        echo "Installing linux-arctis-manager..."
-        pipx install "$WHEEL_FILE"
-    fi
 fi
 
-# Only run setup if not Arch
-if [ "$IS_ARCH" = false ]; then
-    echo "Setting up service and starting..."
-    lam-cli setup --systray-autostart --start-now
+echo "Fetching latest release..."
+DOWNLOAD_URL=$(curl -s https://api.github.com/repos/elegos/Linux-Arctis-Manager/releases/latest | grep -oP '"browser_download_url": "\K[^"]*\.whl' | head -1)
+
+if [ -z "$DOWNLOAD_URL" ]; then
+    echo "Error: Could not fetch latest release"
+    exit 1
 fi
+
+curl -LO "$DOWNLOAD_URL"
+WHEEL_FILE=$(basename "$DOWNLOAD_URL")
+
+# Check if already installed
+if pipx list | grep -q "linux-arctis-manager"; then
+    echo "Upgrading existing installation..."
+    pipx install --force "$WHEEL_FILE"
+else
+    echo "Installing linux-arctis-manager..."
+    pipx install "$WHEEL_FILE"
+fi
+
+# Setup and start service
+echo "Setting up service and starting..."
+lam-cli setup --systray-autostart --start-now
 
 echo "✓ Linux Arctis Manager installed and started!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Linux Arctis Manager - Automated Install Script
+
+set -e
+
+echo "Installing Linux Arctis Manager..."
+
+IS_ARCH=false
+
+# Check for Arch-based systems first
+if command -v yay &> /dev/null; then
+    echo "Detected yay - Installing/upgrading from AUR..."
+    yay -S --noconfirm linux-arctis-manager
+    IS_ARCH=true
+elif command -v paru &> /dev/null; then
+    echo "Detected paru - Installing/upgrading from AUR..."
+    paru -S --noconfirm linux-arctis-manager
+    IS_ARCH=true
+elif command -v pacman &> /dev/null; then
+    echo "Error: Arch detected but no AUR helper (yay/paru) found. Please install one first."
+    exit 1
+else
+    # Check if pipx is installed
+    if ! command -v pipx &> /dev/null; then
+        echo "Error: pipx not found. Please install pipx first."
+        exit 1
+    fi
+    
+    echo "Fetching latest release..."
+    DOWNLOAD_URL=$(curl -s https://api.github.com/repos/elegos/Linux-Arctis-Manager/releases/latest | grep -oP '"browser_download_url": "\K[^"]*\.whl' | head -1)
+    
+    if [ -z "$DOWNLOAD_URL" ]; then
+        echo "Error: Could not fetch latest release"
+        exit 1
+    fi
+    
+    curl -LO "$DOWNLOAD_URL"
+    WHEEL_FILE=$(basename "$DOWNLOAD_URL")
+    
+    # Check if already installed
+    if pipx list | grep -q "linux-arctis-manager"; then
+        echo "Upgrading existing installation..."
+        pipx install --force "$WHEEL_FILE"
+    else
+        echo "Installing linux-arctis-manager..."
+        pipx install "$WHEEL_FILE"
+    fi
+fi
+
+# Only run setup if not Arch
+if [ "$IS_ARCH" = false ]; then
+    echo "Setting up service and starting..."
+    lam-cli setup --systray-autostart --start-now
+fi
+
+echo "✓ Linux Arctis Manager installed and started!"


### PR DESCRIPTION
# Description
Adds automated installation script for Linux Arctis Manager with support for multiple Linux distributions. The script intelligently detects the system and uses the appropriate installation method: AUR for Arch-based systems or pipx for other distributions. It handles both fresh installations and upgrades seamlessly.

## Changes
* **Arch Detection:** Detects Arch Linux and installs directly from AUR using yay or paru, with full automatic configuration.
* **Else:** For non-Arch systems, downloads the latest release from GitHub and installs via pipx, with pipx availability checking.
* **Upgrade Logic:** Checks if linux-arctis-manager is already installed and uses `--force` flag only when upgrading.
* **Configuration Management:** Automatically runs `lam-cli setup --systray-autostart --start-now` for non-Arch installs; Arch AUR package handles this automatically.
* **Error Handling:** Provides clear error messages for missing dependencies (pipx on non-Arch systems, AUR helpers on Arch systems).

Will put in another PR, or have @ifeign add it to their ongoing documentation changes, for the install instructions.

Can be installed with `curl -LsSf https://raw.githubusercontent.com/elegos/Linux-Arctis-Manager/refs/heads/develop/scripts/install.sh | sh`
