### PR TITLE
docs(readme):recommend symlinking for AUR autostart tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ An open-source replacement for SteelSeries GG, to manage your Arctis headset on 
 | Arctis Nova 7+ / PS5 / Xbox / Destiny | ✅ | ✅ | `220e`, `2212`, `2216`, `2236` |
 | Arctis Nova 7P | ❌ | ❌ | `220a` |
 | Arctis Nova Elite | ❌ | ❌ | `2244` |
-| Arctis Nova Pro Wireless / X | ✅ | ✅ | `12e0`, `12e5` |
+| Arctis Nova Pro Wireless / X | ✅ | ✅ | `12e0`, `12e5`, `225d` |
 | Arctis Nova Pro / X (GameDAC Gen2) | ✅ | ✅ | `12cb`, `12cd` |
 
 ### Legend

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ yay -S linux-arctis-manager
 > To launch the system tray app automatically on login:
 >
 > ```bash
-> cp /usr/share/applications/ArctisManagerSystray.desktop ~/.config/autostart/
+> ln -sf /usr/share/applications/ArctisManagerSystray.desktop ~/.config/autostart/
 > ```
 
 > For packaging-specific issues, report directly to the AUR maintainers: [@tonitch](https://aur.archlinux.org/account/tonitch) and [@Aiyahhh](https://aur.archlinux.org/account/Aiyahhh).

--- a/README.md
+++ b/README.md
@@ -185,6 +185,17 @@ lam-cli setup --start-now
 
 ## 🧹 Uninstall / Cleanup
 
+Choose the method that matches your installation method:
+
+### Arch Linux (AUR)
+Use the system package manager:
+
+```bash
+sudo pacman -Rns linux-arctis-manager
+```
+
+### Manual Install
+
 1. Stop and disable the service:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -103,18 +103,24 @@ yay -S linux-arctis-manager
 
 ### Manual Install
 
-> [!NOTE]
-> `pip` can be used instead of `pipx`, but `pipx` is recommended for better dependency isolation. Some distros will require `pipx`.
-
 #### Prerequisites
 
 Install `pipx` with your package manager.
 
-#### Option A: Install from Release (recommended)
-
 > [!NOTE]
-> You can try the automatic installer via `curl -LsSf https://raw.githubusercontent.com/elegos/Linux-Arctis-Manager/refs/heads/main/scripts/install.sh | sh`
-> Nothing else is required.
+> `pip` can be used instead of `pipx`, but `pipx` is recommended for better dependency isolation. Some distros will require `pipx`.
+
+#### Option A: Quick Install (Recommended)
+
+Run the automated install script:
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/elegos/Linux-Arctis-Manager/refs/heads/main/scripts/install.sh | sh
+```
+> [!TIP]
+> If you use the automated script, you can skip the Final Setup section entirely.
+
+#### Option B: Install from Release
 
 1. Download the latest `.whl` from the [releases page](../../releases)
 2. From the directory you downloaded it to, install it:
@@ -127,7 +133,7 @@ Install `pipx` with your package manager.
 
 3. Continue to [Final Setup](#final-setup)
 
-#### Option B: Install from Source
+#### Option C: Install from Source
 
 1. Install `uv` ([installation guide](https://docs.astral.sh/uv/getting-started/installation/)) and create the applications directory:
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,37 @@ lam-cli setup --start-now
 
 Choose the method that matches your installation method:
 
+- **[Distrobox](#distrobox-1)**
+- **[Arch Linux (AUR)](#arch-linux-aur-1)**
+- **[Manual install](#manual-install-1)**
+
+### Distrobox
+
+1. Stop and disable the service:
+   ```bash
+   systemctl --user disable --now arctis-manager
+   rm ~/.config/systemd/user/arctis-manager.service
+   ```
+
+2. Remove the container:
+   ```bash
+   distrobox-rm -f arctis-manager
+   ```
+
+3. Remove leftover host files:
+
+   ```bash
+   # desktop menu entries
+   rm -f ~/.local/share/applications/ArctisManager.desktop
+
+   # udev rules
+   sudo rm -f /etc/udev/rules.d/91-steelseries-arctis.rules
+
+   # user preferences and virtual environment
+   rm -rf ~/.config/arctis_manager
+   rm -rf ~/.local/share/pipx/venvs/linux-arctis-manager
+   ```   
+
 ### Arch Linux (AUR)
 Use the system package manager:
 
@@ -213,7 +244,7 @@ sudo pacman -Rns linux-arctis-manager
    sudo rm -f /etc/udev/rules.d/91-steelseries-arctis.rules
    sudo rm -f /usr/lib/udev/rules.d/91-steelseries-arctis.rules
 
-   # user preferences and device/lang files
+   # user preferences and device files
    rm -rf ~/.config/arctis_manager
    ```
 

--- a/src/linux_arctis_manager/devices/nova_pro_wireless.yaml
+++ b/src/linux_arctis_manager/devices/nova_pro_wireless.yaml
@@ -4,6 +4,7 @@ device:
   product_ids:
     - 0x12e0 # SteelSeries Arctis Nova Pro Wireless
     - 0x12e5 # SteelSeries Arctis Nova Pro Wireless X
+    - 0x225d # SteelSeries Arctis Nova Pro Wireless X
   command_padding:
     length: 64
     position: end


### PR DESCRIPTION
Updated the README to suggest symlinking the .desktop file to 
~/.config/autostart instead of copying it. This ensures that any 
system-level updates to the desktop entry are automatically 
reflected without manual user intervention.