### PR TITLE
feat(systray): add volume limiter toggle to tray menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Added
-- Volume limiter toggle in system tray context menu (shown only for devices that support it)
+- Systray toggles: a new "Systray toggles" section in the main window lets you choose, per device, which of the device's toggle settings appear as quick switches in the system tray menu
 - Live settings synchronization via `SettingsChanged` D-Bus signal subscription
+- `SetSystrayToggle` D-Bus method to pin/unpin a device toggle from the system tray (per-device UI preference)
 
 ## [2.4.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Added
+- Volume limiter toggle in system tray context menu (shown only for devices that support it)
+- Live settings synchronization via `SettingsChanged` D-Bus signal subscription
+
 ## [2.4.1]
 
 ## Added

--- a/docs/dbus.md
+++ b/docs/dbus.md
@@ -26,9 +26,10 @@ The response varies depending on the list, but it will always return a list of o
 - **Response format**: JSON
 - **Specs**:
 
-The response has three sections:
+The response has four sections:
 - `general`: for general (cross-device) settings.
 - `device`: for device-specific settings. Will be an empty object if no device is connected.
+- `systray_toggles`: a list of device setting names the user pinned to the system tray menu. Empty if no device is connected.
 - `settings_config`: the definition for each setting, defining type, default_value and other arguments depending on the type. See **YAML's device.settings.[section].[setting] types**.
 
 The clients shouldn't hard-core the settings, but read them and parse them depending on the `settings_config` section.
@@ -45,6 +46,7 @@ The clients shouldn't hard-core the settings, but read them and parse them depen
         "setting_b": 0,
         "setting_c": 10
     },
+    "systray_toggles": ["toggle_setting"],
     "settings_config": {
         "toggle_setting": {
             "type": "toggle",
@@ -89,6 +91,15 @@ The clients shouldn't hard-core the settings, but read them and parse them depen
 Writes the setting. Searches the setting first in the general settings and then, if not found, in the device's.
 
 Returns boolean (true: setting saved, false: setting not found / not saved)
+
+### Method: SetSystrayToggle
+- **Parameters**: name: string, enabled: boolean
+- **Response format**: boolean
+- **Specs**:
+
+Pins (`enabled = true`) or unpins (`enabled = false`) a device toggle setting from the system tray quick-switch menu. This is a UI preference persisted per device; it does **not** send any command to the device.
+
+Returns `false` if no device is connected, the setting name is unknown for the current device, or the setting is not of type `toggle`. On success, emits `SettingsChanged`.
 
 ## name.giacomofurlan.ArctisManager.Next.Status
 

--- a/src/linux_arctis_manager/core.py
+++ b/src/linux_arctis_manager/core.py
@@ -44,6 +44,7 @@ class CoreEngine:
     device_status_observers: list[Callable[[dict[str, int]], None]]
     device_settings_observers: list[Callable[[DeviceSettings], None]]
     general_settings_observers: list[Callable[[GeneralSettings], None]]
+    settings_observers: list[Callable[[], None]]
     
     def __init__(self) -> None:
         self.media_mix = 100
@@ -51,6 +52,7 @@ class CoreEngine:
         self.device_status_observers = []
         self.device_settings_observers = []
         self.general_settings_observers = []
+        self.settings_observers = []
 
         self.general_settings = GeneralSettings.read_from_file()
 
@@ -260,7 +262,9 @@ class CoreEngine:
         self.pa_audio_manager.sinks_setup(self.device_config.name, self.device_config.vendor_id, self.device_config.product_ids)
 
         self.redirect_to_media_sink()
-    
+
+        self.notify_settings_changed()
+
     def init_device(self):
         self.logger.info("Initializing device...")
         if self.device_config and self.device_config.device_init:
@@ -283,7 +287,15 @@ class CoreEngine:
     def register_status_observer(self, observer: Callable[[dict[str, int]], None]):
         if observer not in self.device_status_observers:
             self.device_status_observers.append(observer)
-    
+
+    def register_settings_observer(self, observer: Callable[[], None]):
+        if observer not in self.settings_observers:
+            self.settings_observers.append(observer)
+
+    def notify_settings_changed(self):
+        for observer in self.settings_observers:
+            observer()
+
     def on_device_status_changed(self, key: str, value: int):
         if self.device_config and self.device_config.online_status and key == self.device_config.online_status.status_variable:
             if self.is_device_online():
@@ -482,3 +494,5 @@ class CoreEngine:
         self.usb_device = None
         self.device_config = None
         self.device_status = None
+
+        self.notify_settings_changed()

--- a/src/linux_arctis_manager/dbus_service.py
+++ b/src/linux_arctis_manager/dbus_service.py
@@ -6,7 +6,8 @@ import logging
 from dbus_next.aio.message_bus import MessageBus
 from dbus_next.service import ServiceInterface, method, signal
 
-from linux_arctis_manager.config import DeviceConfiguration, parsed_status
+from linux_arctis_manager.config import (DeviceConfiguration, SettingType,
+                                         parsed_status)
 from linux_arctis_manager.constants import (DBUS_BUS_NAME,
                                             DBUS_CONFIG_INTERFACE_NAME,
                                             DBUS_CONFIG_OBJECT_PATH,
@@ -81,11 +82,28 @@ class ArctisManagerDbusSettingsService(ServiceInterface):
         super().__init__(DBUS_SETTINGS_INTERFACE_NAME)
         self.core_engine = core
         self.logger = logging.getLogger('ArctisManagerDbusSettingsService')
-    
+        self.last_settings = ''
+        self.core_engine.register_settings_observer(self._on_settings_changed)
+
+    def _on_settings_changed(self) -> None:
+        dumped = self.settings_to_json(
+            self.core_engine.general_settings,
+            self.core_engine.device_config,
+            self.core_engine.device_settings,
+        )
+
+        if dumped == self.last_settings:
+            return
+
+        self.last_settings = dumped
+
+        self.signal_settings_changed(dumped)
+
     def settings_to_json(self, general_settings: GeneralSettings, device_config: DeviceConfiguration|None, device_settings: DeviceSettings|None) -> str:
         settings = {
             'general': general_settings.to_dict(),
             'device': {},
+            'systray_toggles': [],
             'settings_config': {
                 config.name: config.to_dict()
                 for config in self.core_engine.general_settings.settings_config
@@ -93,9 +111,8 @@ class ArctisManagerDbusSettingsService(ServiceInterface):
         }
 
         if device_config and device_settings:
-            settings.update({'device': device_settings.settings})
-        if device_config and device_settings:
-            settings.update({'device': device_settings.settings})
+            settings['device'] = dict(device_settings.settings)
+            settings['systray_toggles'] = list(device_settings.systray_toggles)
             settings['settings_config'].update({
                 config.name: config.to_dict()
                 for config in list(itertools.chain.from_iterable(
@@ -161,7 +178,51 @@ class ArctisManagerDbusSettingsService(ServiceInterface):
                 return True
 
         return False
-    
+
+    def set_systray_toggle(self, name: str, enabled: bool) -> bool:
+        if not self.core_engine.device_config or not self.core_engine.device_settings:
+            self.logger.error('SetSystrayToggle: no device connected')
+            return False
+
+        config = next((
+            cfg
+            for section in self.core_engine.device_config.settings.values()
+            for cfg in section
+            if cfg.name == name
+        ), None)
+
+        if not config:
+            self.logger.error(f'SetSystrayToggle: unknown setting "{name}" for the current device')
+            return False
+
+        if config.type != SettingType.TOGGLE:
+            self.logger.error(f'SetSystrayToggle: setting "{name}" is not a toggle')
+            return False
+
+        toggles = self.core_engine.device_settings.systray_toggles
+        mutated = False
+        if enabled and name not in toggles:
+            toggles.append(name)
+            mutated = True
+        elif not enabled and name in toggles:
+            toggles.remove(name)
+            mutated = True
+
+        if mutated:
+            self.core_engine.device_settings.write_to_file()
+            self.last_settings = self.settings_to_json(
+                self.core_engine.general_settings,
+                self.core_engine.device_config,
+                self.core_engine.device_settings,
+            )
+            self.signal_settings_changed(self.last_settings)
+
+        return True
+
+    @method('SetSystrayToggle')
+    def _dbus_set_systray_toggle(self, name: 's', enabled: 'b') -> 'b': # type: ignore
+        return self.set_systray_toggle(name, enabled)
+
     @method('GetListOptions')
     def get_list_options(self, list_name: 's') -> 's': # type: ignore
         result = []

--- a/src/linux_arctis_manager/gui/dbus_wrapper.py
+++ b/src/linux_arctis_manager/gui/dbus_wrapper.py
@@ -170,4 +170,26 @@ class DbusWrapper(QObject):
             signature='ss',
             body=[name, json.dumps(value)],
         ))
+
+    @staticmethod
+    def set_systray_toggle(name: str, enabled: bool) -> None:
+        request_thread = Thread(target=DbusWrapper.set_systray_toggle_thread, kwargs={'name': name, 'enabled': enabled})
+        request_thread.start()
+
+    @staticmethod
+    def set_systray_toggle_thread(name: str, enabled: bool):
+        asyncio.run(DbusWrapper.set_systray_toggle_async(name, enabled))
+
+    @staticmethod
+    async def set_systray_toggle_async(name: str, enabled: bool):
+        dbus_bus = await MessageBus().connect()
+        await dbus_bus.call(Message(
+            destination=DBUS_BUS_NAME,
+            path=DBUS_SETTINGS_OBJECT_PATH,
+            interface=DBUS_SETTINGS_INTERFACE_NAME,
+            member='SetSystrayToggle',
+            message_type=MessageType.METHOD_CALL,
+            signature='sb',
+            body=[name, enabled],
+        ))
     

--- a/src/linux_arctis_manager/gui/dbus_wrapper.py
+++ b/src/linux_arctis_manager/gui/dbus_wrapper.py
@@ -32,6 +32,9 @@ class DbusWrapper(QObject):
         self._status_signal_loop: asyncio.AbstractEventLoop|None = None
         self._stop_status_signal_future: asyncio.Future|None = None
 
+        self._settings_signal_loop: asyncio.AbstractEventLoop|None = None
+        self._stop_settings_signal_future: asyncio.Future|None = None
+
         self._status_iface: ProxyInterface|None = None
 
     async def status_iface(self):
@@ -58,7 +61,10 @@ class DbusWrapper(QObject):
 
         status_signal_thread = Thread(target=lambda: asyncio.run(self._register_status_dbus_signal()))
         status_signal_thread.start()
-    
+
+        settings_signal_thread = Thread(target=lambda: asyncio.run(self._register_settings_dbus_signal()))
+        settings_signal_thread.start()
+
     async def _register_status_dbus_signal(self):
         def callback(status: str) -> None:
             self.sig_status.emit(json.loads(status) or {})
@@ -69,11 +75,27 @@ class DbusWrapper(QObject):
         self._stop_status_signal_future = self._status_signal_loop.create_future()
         await self._stop_status_signal_future
 
+    async def _register_settings_dbus_signal(self):
+        def callback(settings: str) -> None:
+            self.sig_settings.emit(json.loads(settings) or {})
+
+        bus = await MessageBus().connect()
+        introspection = await bus.introspect(DBUS_BUS_NAME, DBUS_SETTINGS_OBJECT_PATH)
+        obj = bus.get_proxy_object(DBUS_BUS_NAME, DBUS_SETTINGS_OBJECT_PATH, introspection)
+        iface = obj.get_interface(DBUS_SETTINGS_INTERFACE_NAME)
+        iface.on_settings_changed(callback) # type: ignore
+
+        self._settings_signal_loop = asyncio.get_running_loop()
+        self._stop_settings_signal_future = self._settings_signal_loop.create_future()
+        await self._stop_settings_signal_future
+
     def stop(self):
         self.logger.info("Stopping D-Bus wrapper...")
         self._stopping = True
         if self._status_signal_loop and self._stop_status_signal_future:
             self._status_signal_loop.call_soon_threadsafe(self._stop_status_signal_future.set_result, None)
+        if self._settings_signal_loop and self._stop_settings_signal_future:
+            self._settings_signal_loop.call_soon_threadsafe(self._stop_settings_signal_future.set_result, None)
 
     def request_status(self) -> None:
         request_thread = Thread(target=lambda: asyncio.run(self._request_status_async()))

--- a/src/linux_arctis_manager/gui/main_app.py
+++ b/src/linux_arctis_manager/gui/main_app.py
@@ -10,6 +10,7 @@ from linux_arctis_manager.gui.base_app import QBaseDesktopApp
 from linux_arctis_manager.gui.dbus_wrapper import DbusWrapper
 from linux_arctis_manager.gui.main_app_proto_widget import QMainAppProtoWidget
 from linux_arctis_manager.gui.settings_widget import QSettingsWidget
+from linux_arctis_manager.gui.systray_toggles_widget import QSystrayTogglesWidget
 from linux_arctis_manager.gui.status_widget import QStatusWidget
 from linux_arctis_manager.gui.ui_utils import get_icon_pixmap
 from linux_arctis_manager.i18n import I18n
@@ -44,11 +45,13 @@ class QMainApp(QBaseDesktopApp):
         self.status_widget = QStatusWidget(self.main_panel)
         self.general_settings_widget = QSettingsWidget(self.main_panel, 'general', 'general')
         self.device_settings_widget = QSettingsWidget(self.main_panel, 'device', 'device')
+        self.systray_toggles_widget = QSystrayTogglesWidget(self.main_panel)
 
         self.main_panel_widgets: dict[str, QWidget] = {
             'status': self.status_widget,
             'general': self.general_settings_widget,
             'device': self.device_settings_widget,
+            'systray_toggles': self.systray_toggles_widget,
         }
 
         for widget in self.main_panel_widgets.values():
@@ -58,6 +61,7 @@ class QMainApp(QBaseDesktopApp):
         self.dbus_wrapper.sig_status.connect(self.status_widget.update_status)
         self.dbus_wrapper.sig_settings.connect(self.general_settings_widget.update_settings)
         self.dbus_wrapper.sig_settings.connect(self.device_settings_widget.update_settings)
+        self.dbus_wrapper.sig_settings.connect(self.systray_toggles_widget.update_settings)
 
         self.switch_panel('status')
         self.dbus_wrapper.start()
@@ -99,6 +103,7 @@ class QMainApp(QBaseDesktopApp):
             ('status', I18n.get_instance().translate('ui', 'status')),
             ('general', I18n.get_instance().translate('ui', 'general')),
             ('device', I18n.get_instance().translate('ui', 'device')),
+            ('systray_toggles', I18n.get_instance().translate('ui', 'systray_toggles')),
         ]
 
         for value, text in self.side_panel_items:
@@ -118,7 +123,7 @@ class QMainApp(QBaseDesktopApp):
 
         return window
     
-    def switch_panel(self, panel: Literal['status', 'general', 'device']) -> None:
+    def switch_panel(self, panel: Literal['status', 'general', 'device', 'systray_toggles']) -> None:
         if not self.main_panel_widgets[panel].isHidden():
             return
 

--- a/src/linux_arctis_manager/gui/systray_app.py
+++ b/src/linux_arctis_manager/gui/systray_app.py
@@ -96,25 +96,34 @@ class QSystrayApp(QBaseDesktopApp):
 
         device_settings = self.last_device_settings.get('device', {})
         settings_config = self.last_device_settings.get('settings_config', {})
+        pinned = self.last_device_settings.get('systray_toggles', [])
 
-        if 'volume_limiter' in settings_config:
-            volume_limiter_config = settings_config['volume_limiter']
-            on_value = volume_limiter_config.get('values', {}).get('on', 1)
-            off_value = volume_limiter_config.get('values', {}).get('off', 0)
-            current_value = device_settings.get('volume_limiter', off_value)
+        for name in pinned:
+            config = settings_config.get(name)
+            if not config or config.get('type') != 'toggle':
+                continue
+
+            values = config.get('values', {})
+            # Device settings are stored as ints; coerce so the values sent over
+            # D-Bus match the int-typed default and aren't rejected as a type mismatch.
+            on_value = int(values.get('on', 1))
+            off_value = int(values.get('off', 0))
+            current_value = device_settings.get(name, off_value)
             is_on = current_value == on_value
 
-            self._menu_actions['volume_limiter'] = QAction(I18n.translate('settings', 'volume_limiter'))
-            self._menu_actions['volume_limiter'].setCheckable(True)
-            self._menu_actions['volume_limiter'].setChecked(is_on)
+            action = QAction(I18n.translate('settings', name))
+            action.setCheckable(True)
+            action.setChecked(is_on)
 
-            def _toggle_volume_limiter(checked, on_val=on_value, off_val=off_value):
+            def _toggle(checked, n=name, on_val=on_value, off_val=off_value):
                 new_value = on_val if checked else off_val
-                self.last_device_settings.get('device', {})['volume_limiter'] = new_value
-                DbusWrapper.change_setting('volume_limiter', new_value)
+                if 'device' in self.last_device_settings:
+                    self.last_device_settings['device'][n] = new_value
+                DbusWrapper.change_setting(n, new_value)
 
-            self._menu_actions['volume_limiter'].triggered.connect(_toggle_volume_limiter)
-            self.menu.addAction(self._menu_actions['volume_limiter'])
+            action.triggered.connect(_toggle)
+            self._menu_actions['toggle_' + name] = action
+            self.menu.addAction(action)
 
         sections = 0
         for _, status_obj in self.last_device_status.items():

--- a/src/linux_arctis_manager/gui/systray_app.py
+++ b/src/linux_arctis_manager/gui/systray_app.py
@@ -51,6 +51,7 @@ class QSystrayApp(QBaseDesktopApp):
         lang_code = lang_code.split('_')[0] if lang_code else 'en'
 
         self.last_device_status = {}
+        self.last_device_settings = {}
 
         self.menu = QMenu()
         self.menu_setup()
@@ -60,6 +61,7 @@ class QSystrayApp(QBaseDesktopApp):
 
         self.dbus_wrapper = DbusWrapper()
         self.dbus_wrapper.sig_status.connect(lambda status: self.new_status.emit(status or {}))
+        self.dbus_wrapper.sig_settings.connect(self.on_new_settings)
 
         self.tray_icon.setContextMenu(self.menu)
     
@@ -68,6 +70,13 @@ class QSystrayApp(QBaseDesktopApp):
             return
 
         self.last_device_status = status
+        self.menu_setup()
+
+    def on_new_settings(self, settings: dict):
+        if self.last_device_settings == settings:
+            return
+
+        self.last_device_settings = settings
         self.menu_setup()
 
     async def start(self):
@@ -84,6 +93,28 @@ class QSystrayApp(QBaseDesktopApp):
         self._menu_actions['open_app'] = QAction(I18n.translate('ui', 'open_app'))
         self._menu_actions['open_app'].triggered.connect(self.open_main_window)
         self.menu.addAction(self._menu_actions['open_app'])
+
+        device_settings = self.last_device_settings.get('device', {})
+        settings_config = self.last_device_settings.get('settings_config', {})
+
+        if 'volume_limiter' in settings_config:
+            volume_limiter_config = settings_config['volume_limiter']
+            on_value = volume_limiter_config.get('values', {}).get('on', 1)
+            off_value = volume_limiter_config.get('values', {}).get('off', 0)
+            current_value = device_settings.get('volume_limiter', off_value)
+            is_on = current_value == on_value
+
+            self._menu_actions['volume_limiter'] = QAction(I18n.translate('settings', 'volume_limiter'))
+            self._menu_actions['volume_limiter'].setCheckable(True)
+            self._menu_actions['volume_limiter'].setChecked(is_on)
+
+            def _toggle_volume_limiter(checked, on_val=on_value, off_val=off_value):
+                new_value = on_val if checked else off_val
+                self.last_device_settings.get('device', {})['volume_limiter'] = new_value
+                DbusWrapper.change_setting('volume_limiter', new_value)
+
+            self._menu_actions['volume_limiter'].triggered.connect(_toggle_volume_limiter)
+            self.menu.addAction(self._menu_actions['volume_limiter'])
 
         sections = 0
         for _, status_obj in self.last_device_status.items():

--- a/src/linux_arctis_manager/gui/systray_toggles_widget.py
+++ b/src/linux_arctis_manager/gui/systray_toggles_widget.py
@@ -1,0 +1,73 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QCheckBox, QLabel, QVBoxLayout, QWidget
+
+from linux_arctis_manager.gui.dbus_wrapper import DbusWrapper
+from linux_arctis_manager.i18n import I18n
+
+
+class QSystrayTogglesWidget(QWidget):
+    def __init__(self, parent: QWidget):
+        super().__init__(parent)
+
+        layout = QVBoxLayout()
+        layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+        self.setLayout(layout)
+
+        title = I18n.get_instance().translate('ui', 'systray_toggles')
+        title_widget = QLabel(title)
+        title_font = title_widget.font()
+        title_font.setBold(True)
+        title_font.setPointSize(16)
+        title_widget.setFont(title_font)
+        layout.addWidget(title_widget)
+
+        hint = QLabel(I18n.get_instance().translate('ui', 'systray_toggles_hint'))
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
+        self.main_layout = QVBoxLayout()
+        layout.addLayout(self.main_layout)
+
+        self._checkboxes: dict[str, QCheckBox] = {}
+        self._rendered: dict[str, bool] | None = None
+
+    def update_settings(self, new_settings: dict):
+        settings_config = new_settings.get('settings_config', {}) or {}
+        device_settings = new_settings.get('device', {}) or {}
+        pinned = new_settings.get('systray_toggles', []) or []
+
+        # Only device-scoped TOGGLE settings are eligible for the tray
+        toggle_names = [
+            name for name, config in settings_config.items()
+            if config.get('type') == 'toggle' and name in device_settings
+        ]
+
+        # Skip the rebuild when nothing relevant changed
+        desired = {name: name in pinned for name in toggle_names}
+        if desired == self._rendered:
+            return
+        self._rendered = desired
+
+        # Clear the previous contents (remove layout items, not just the widgets)
+        while self.main_layout.count():
+            item = self.main_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        self._checkboxes = {}
+
+        if not toggle_names:
+            empty = QLabel(I18n.get_instance().translate('ui', 'systray_toggles_empty'))
+            empty.setWordWrap(True)
+            self.main_layout.addWidget(empty)
+            return
+
+        for name in toggle_names:
+            checkbox = QCheckBox(I18n.get_instance().translate('settings', name))
+            checkbox.setChecked(desired[name])
+
+            def _on_toggled(checked, n=name):
+                DbusWrapper.set_systray_toggle(n, checked)
+
+            checkbox.toggled.connect(_on_toggled)
+            self._checkboxes[name] = checkbox
+            self.main_layout.addWidget(checkbox)

--- a/src/linux_arctis_manager/lang/en.ini
+++ b/src/linux_arctis_manager/lang/en.ini
@@ -98,3 +98,6 @@ exit = Exit
 status = Status
 general = General
 device = Device
+systray_toggles = Systray toggles
+systray_toggles_hint = Choose which of this device's toggle settings appear as quick switches in the system tray menu.
+systray_toggles_empty = Connect a device with toggle settings to choose tray shortcuts.

--- a/src/linux_arctis_manager/settings.py
+++ b/src/linux_arctis_manager/settings.py
@@ -13,11 +13,13 @@ class DeviceSettings(JsonSerializable):
     product_id: int
 
     settings: ObservableDict[str, int]
+    systray_toggles: list[str]
 
     def __init__(self, vendor_id: int, product_id: int):
         self.vendor_id = vendor_id
         self.product_id = product_id
         self.settings = ObservableDict()
+        self.systray_toggles = []
 
     def _settings_file(self) -> Path:
         settings_file = SETTINGS_FOLDER / f'{self.vendor_id:04x}_{self.product_id:04x}.yaml'
@@ -33,28 +35,42 @@ class DeviceSettings(JsonSerializable):
         yaml = YAML(typ='safe')
         raw = yaml.load(settings_file) or {}
 
-        for key in raw:
+        # New format is keyed ({settings: {...}, systray_toggles: [...]}); detect it
+        # by the value shapes, not just key presence, so an old flat file that
+        # happens to contain an int-valued key named 'settings' is not mistaken
+        # for the new format. Older files are a flat {name: int} map (else branch).
+        if isinstance(raw.get('settings'), dict) or isinstance(raw.get('systray_toggles'), list):
+            saved_settings = raw.get('settings') or {}
+            self.systray_toggles = list(raw.get('systray_toggles') or [])
+        else:
+            # Backward compatibility: old flat {name: int} format
+            saved_settings = raw
+
+        for key in saved_settings:
             # Clean old / invalid settings
             if key in self.settings:
-                self.settings[key] = int(raw[key])
+                self.settings[key] = int(saved_settings[key])
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name in ('vendor_id', 'product_id', 'settings'):
+        if name in ('vendor_id', 'product_id', 'settings', 'systray_toggles'):
             super().__setattr__(name, value)
 
             return
 
         self.settings[name] = int(value)
-    
+
     def get(self, name: str, default: int = 0) -> int:
         return self.settings.get(name, default)
 
     def write_to_file(self):
         settings_file = self._settings_file()
         settings_file.parent.mkdir(parents=True, exist_ok=True)
-        
+
         yaml = YAML(typ='safe')
-        yaml.dump(self.settings.to_dict(), settings_file)
+        yaml.dump({
+            'settings': self.settings.to_dict(),
+            'systray_toggles': list(self.systray_toggles),
+        }, settings_file)
 
     def to_dict(self) -> dict:
         return self.__dict__

--- a/tests/linux_arctis_manager/test_dbus_service.py
+++ b/tests/linux_arctis_manager/test_dbus_service.py
@@ -1,0 +1,171 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import linux_arctis_manager.settings as settings_mod
+from linux_arctis_manager.config import DeviceConfiguration
+from linux_arctis_manager.dbus_service import ArctisManagerDbusSettingsService
+from linux_arctis_manager.settings import DeviceSettings, GeneralSettings
+
+
+def _device_config_with_toggle() -> DeviceConfiguration:
+    raw = {
+        'device': {
+            'name': 'Test Device',
+            'vendor_id': 0x1234,
+            'product_ids': [0xabcd],
+            'command_interface_index': [0, 0],
+            'listen_interface_indexes': [0],
+            'command_padding': {'length': 64, 'position': 'end', 'filler': 0x00},
+            'settings': {
+                'headset': {
+                    'volume_limiter': {
+                        'type': 'toggle',
+                        'default': 0,
+                        'values': {'on': 1, 'off': 0},
+                    },
+                    'sidetone': {
+                        'type': 'slider',
+                        'default': 0,
+                        'min': 0,
+                        'max': 3,
+                        'step': 1,
+                    },
+                },
+            },
+        }
+    }
+    return DeviceConfiguration(raw)
+
+
+def _make_service(tmp_path, monkeypatch, with_device=True):
+    monkeypatch.setattr(settings_mod, 'SETTINGS_FOLDER', tmp_path)
+
+    device_config = _device_config_with_toggle() if with_device else None
+    device_settings = None
+    if with_device:
+        device_settings = DeviceSettings(0x1234, 0xabcd)
+        device_settings.settings['volume_limiter'] = 0
+        device_settings.settings['sidetone'] = 0
+
+    core = SimpleNamespace(
+        general_settings=GeneralSettings(),
+        device_config=device_config,
+        device_settings=device_settings,
+        register_settings_observer=lambda observer: None,
+    )
+    service = ArctisManagerDbusSettingsService(core)
+    service.signal_settings_changed = MagicMock()  # avoid emitting on a real bus
+    return service, core
+
+
+def test_settings_to_json_includes_systray_toggles(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+    core.device_settings.systray_toggles = ['volume_limiter']
+
+    payload = json.loads(service.settings_to_json(
+        core.general_settings, core.device_config, core.device_settings))
+
+    assert payload['systray_toggles'] == ['volume_limiter']
+
+
+def test_settings_to_json_systray_toggles_empty_without_device(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch, with_device=False)
+
+    payload = json.loads(service.settings_to_json(
+        core.general_settings, None, None))
+
+    assert payload['systray_toggles'] == []
+
+
+def test_set_systray_toggle_adds_toggle(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+
+    result = service.set_systray_toggle('volume_limiter', True)
+
+    assert result is True
+    assert core.device_settings.systray_toggles == ['volume_limiter']
+    service.signal_settings_changed.assert_called_once()
+
+
+def test_set_systray_toggle_removes_toggle(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+    core.device_settings.systray_toggles = ['volume_limiter']
+
+    result = service.set_systray_toggle('volume_limiter', False)
+
+    assert result is True
+    assert core.device_settings.systray_toggles == []
+
+
+def test_set_systray_toggle_rejects_non_toggle_setting(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+
+    result = service.set_systray_toggle('sidetone', True)
+
+    assert result is False
+    assert core.device_settings.systray_toggles == []
+
+
+def test_set_systray_toggle_rejects_unknown_setting(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+
+    result = service.set_systray_toggle('does_not_exist', True)
+
+    assert result is False
+
+
+def test_set_systray_toggle_rejects_when_no_device(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch, with_device=False)
+
+    result = service.set_systray_toggle('volume_limiter', True)
+
+    assert result is False
+
+
+def test_set_systray_toggle_noop_when_already_pinned_does_not_emit(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+    core.device_settings.systray_toggles = ['volume_limiter']
+
+    result = service.set_systray_toggle('volume_limiter', True)
+
+    assert result is True
+    assert core.device_settings.systray_toggles == ['volume_limiter']
+    service.signal_settings_changed.assert_not_called()
+
+
+def test_set_systray_toggle_noop_when_already_absent_does_not_emit(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+
+    result = service.set_systray_toggle('volume_limiter', False)
+
+    assert result is True
+    assert core.device_settings.systray_toggles == []
+    service.signal_settings_changed.assert_not_called()
+
+
+def test_on_settings_changed_emits_when_changed(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+
+    service._on_settings_changed()
+
+    service.signal_settings_changed.assert_called_once()
+
+
+def test_on_settings_changed_dedups_identical_payload(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+
+    service._on_settings_changed()
+    service._on_settings_changed()  # identical payload -> no second emit
+
+    service.signal_settings_changed.assert_called_once()
+
+
+def test_on_settings_changed_emits_again_after_real_change(tmp_path, monkeypatch):
+    service, core = _make_service(tmp_path, monkeypatch)
+
+    service._on_settings_changed()
+    core.device_settings.systray_toggles = ['volume_limiter']
+    service._on_settings_changed()
+
+    assert service.signal_settings_changed.call_count == 2

--- a/tests/linux_arctis_manager/test_settings.py
+++ b/tests/linux_arctis_manager/test_settings.py
@@ -1,0 +1,45 @@
+import linux_arctis_manager.settings as settings_mod
+from linux_arctis_manager.settings import DeviceSettings
+from ruamel.yaml import YAML
+
+
+def test_systray_toggles_defaults_to_empty_list():
+    ds = DeviceSettings(0x1234, 0xabcd)
+    assert ds.systray_toggles == []
+
+
+def test_setattr_systray_toggles_does_not_leak_into_settings():
+    ds = DeviceSettings(0x1234, 0xabcd)
+    ds.systray_toggles = ['volume_limiter']
+    assert ds.systray_toggles == ['volume_limiter']
+    assert 'systray_toggles' not in ds.settings
+
+
+def test_write_then_read_new_format_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings_mod, 'SETTINGS_FOLDER', tmp_path)
+
+    ds = DeviceSettings(0x1234, 0xabcd)
+    ds.settings['volume_limiter'] = 1
+    ds.systray_toggles = ['volume_limiter']
+    ds.write_to_file()
+
+    ds2 = DeviceSettings(0x1234, 0xabcd)
+    ds2.settings['volume_limiter'] = 0  # default must be present for read to overlay
+    ds2.read_from_file()
+
+    assert ds2.settings['volume_limiter'] == 1
+    assert ds2.systray_toggles == ['volume_limiter']
+
+
+def test_read_old_flat_format_keeps_settings_and_empty_toggles(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings_mod, 'SETTINGS_FOLDER', tmp_path)
+
+    yaml = YAML(typ='safe')
+    yaml.dump({'volume_limiter': 1}, tmp_path / '1234_abcd.yaml')
+
+    ds = DeviceSettings(0x1234, 0xabcd)
+    ds.settings['volume_limiter'] = 0
+    ds.read_from_file()
+
+    assert ds.settings['volume_limiter'] == 1
+    assert ds.systray_toggles == []


### PR DESCRIPTION
## What
  Adds a volume limiter toggle to the system tray context menu,
  positioned below "Open Arctis Manager".

  The toggle is only shown when the connected device supports
  volume limiter (Nova 5, Nova 7, Nova Pro).

  ## Why
  Previously, toggling volume limiter required opening the full
  main window. This makes it accessible with a single right-click
  on the tray icon.

  ## Changes
  - `systray_app.py`: subscribe to settings, add checkable
    QAction for volume limiter
  - `dbus_wrapper.py`: subscribe to SettingsChanged D-Bus signal
    so all clients stay in sync when settings change from any source