### PR TITLE
docs(readme):Update README with startup service instructions for AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ yay -S linux-arctis-manager
 # using paru: paru -S linux-arctis-manager
 ```
 
+Start the background service automatically on startup:
+
+```bash
+systemctl --user enable arctis-manager
+```
+
 > [!TIP]
 > To launch the system tray app automatically on login:
 >


### PR DESCRIPTION
Add instructions to enable arctis-manager service on startup for AUR install to reflect recent AUR packaging changes