### PR TITLE
Fixed desktop files to validate properly

### DIFF
--- a/src/linux_arctis_manager/desktop/ArctisManager.desktop
+++ b/src/linux_arctis_manager/desktop/ArctisManager.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Arctis Manager
-Exec=/bin/sh -c 'exec lam-gui >/dev/null 2>&1'
+Exec=lam-gui %u
 Icon=arctis-manager
 Type=Application
 Terminal=false

--- a/src/linux_arctis_manager/desktop/ArctisManagerSystray.desktop
+++ b/src/linux_arctis_manager/desktop/ArctisManagerSystray.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Arctis Manager (system tray)
-Exec=/bin/sh -c 'exec lam-gui --systray >/dev/null 2>&1'
+Exec=lam-gui --systray
 Icon=arctis-manager
 Type=Application
 Terminal=false


### PR DESCRIPTION
Working on packaging this for Fedora.

The .desktop files contained bad arguments for the Exec lines which failed validation, which I fixed.

One issue remains after this: I cannot find an icon named 'arctis-manager' in the repo, is that an omission?