### PR TITLE
Feat/add gamebuds support

### DIFF
--- a/src/linux_arctis_manager/config.py
+++ b/src/linux_arctis_manager/config.py
@@ -161,6 +161,8 @@ class DeviceConfiguration:
         raw_device_init = raw_config.get('device_init', None)
         if raw_device_init is not None:
             self.device_init = raw_device_init
+        else:
+            self.device_init = None
         
         raw_status = raw_config.get('status', {})
         if raw_status:
@@ -169,6 +171,8 @@ class DeviceConfiguration:
                 response_mapping=raw_status.get('response_mapping', []),
                 representation=raw_status.get('representation', {}),
             )
+        else:
+            self.status = None
         
         raw_status_parse: dict[str, dict[str, Any]] = raw_config.get('status_parse', {})
         self.status_parse = {}

--- a/src/linux_arctis_manager/devices/gamebuds.yaml
+++ b/src/linux_arctis_manager/devices/gamebuds.yaml
@@ -1,0 +1,95 @@
+device:
+  name: SteelSeries Arctis GameBuds (PS5/PC)
+  vendor_id: 0x1038
+  product_ids:
+    - 0x230a
+  command_padding:
+    length: 64
+    position: end
+    filler: 0x00
+  command_interface_index: [0, 3]
+  listen_interface_indexes: [3]
+
+  device_init:
+    - [0x37, 'settings.mic_volume']
+    - [0x39, 'settings.mic_side_tone']
+    - [0xbd, 'settings.noise_cancelling']
+    - [0xb9, 'settings.noise_level']
+    - [0xc1, 'settings.pm_shutdown']
+    - [0xc5, 'settings.volume_limiter']
+    - [0x27, 'settings.wear_sense']
+    - [0x09]
+
+  settings:
+    microphone:
+      mic_volume:
+        type: slider
+        min: 0x00
+        max: 0x0a
+        step: 1
+        min_label: mic_muted
+        max_label: perc_100
+        default: 0x0a
+        update_sequence: [0x37, 'value']
+      mic_side_tone:
+        type: discrete_map
+        values_mapping:
+          0x00: off
+          0x03: low
+          0x06: medium
+          0x0a: high
+        default: 0x00
+        update_sequence: [0x39, 'value']
+    audio:
+      noise_cancelling:
+        type: discrete_map
+        values_mapping:
+          0x00: off
+          0x01: transparent
+          0x02: on
+        default: 0x00
+        update_sequence: [0xbd, 'value']
+      noise_level:
+        type: slider
+        min: 0x00
+        max: 0x0a
+        step: 1
+        min_label: perc_0
+        max_label: perc_100
+        default: 0x06
+        update_sequence: [0xb9, 'value']
+    headset:
+      volume_limiter:
+        type: toggle
+        values:
+          off: 0x00
+          on: 0x01
+          off_label: off
+          on_label: on
+        default: 0x00
+        update_sequence: [0xc5, 'value']
+      wear_sense:
+        type: toggle
+        values:
+          off: 0x00
+          on: 0x01
+          off_label: off
+          on_label: on
+        default: 0x01
+        update_sequence: [0x27, 'value']
+    power_management:
+      pm_shutdown:
+        type: discrete_map
+        values_mapping:
+          0x00: never
+          0x01: 1_minute
+          0x05: 5_minutes
+          0x0a: 10_minutes
+          0x0f: 15_minutes
+          0x1e: 30_minutes
+          0x2d: 45_minutes
+          0x3c: 60_minutes
+          0x4b: 75_minutes
+          0x5a: 90_minutes
+        default: 0x1e
+        update_sequence: [0xc1, 'value']


### PR DESCRIPTION
This PR introduces initial configuration support for the SteelSeries Arctis GameBuds (PS5/PC) (PID: 0x230a).

Changes Included:

    Added: src/linux_arctis_manager/devices/gamebuds.yaml - Initial device configuration mapping to enable standard control-transfer parameters.

    Modified (Bug Fix): src/linux_arctis_manager/config.py - Fixed an AttributeError in the DeviceConfiguration class. Previously, if a device configuration YAML lacked a status or device_init block, the respective attributes were never initialized in the class constructor. This caused the daemon to crash (AttributeError: 'DeviceConfiguration' object has no attribute 'status') when polling the device state. Added explicit fallback assignments (self.status = None and self.device_init = None) to safely handle devices with unmapped telemetry.

Integration Test Report & Known Limitations

1. General Overview
The device successfully communicates via USB ctrl_transfer. Virtual audio sinks ("media" and "chat") are created without issues. However, due to missing telemetry data (status block) in gamebuds.yaml, some UI and synchronization limitations exist.

### Pull Request Description

**Title:** feat: add initial support for SteelSeries Arctis GameBuds (PS5/PC)

**Description:**
This PR introduces initial configuration support for the SteelSeries Arctis GameBuds (PS5/PC) (PID: `0x230a`).

**Changes Included:**
*   **Added:** `src/linux_arctis_manager/devices/gamebuds.yaml` - Initial device configuration mapping to enable standard control-transfer parameters.
*   **Modified (Bug Fix):** `src/linux_arctis_manager/config.py` - Fixed an `AttributeError` in the `DeviceConfiguration` class. Previously, if a device configuration YAML lacked a `status` or `device_init` block, the respective attributes were never initialized in the class constructor. This caused the daemon to crash (`AttributeError: 'DeviceConfiguration' object has no attribute 'status'`) when polling the device state. Added explicit fallback assignments (`self.status = None` and `self.device_init = None`) to safely handle devices with unmapped telemetry.

#### Integration Test Report & Known Limitations

**1. General Overview**
The device successfully communicates via USB `ctrl_transfer`. Virtual audio sinks ("media" and "chat") are created without issues. However, due to missing telemetry data (status block) in `gamebuds.yaml`, some UI and synchronization limitations exist.

**2. Tab-Specific Test Results**

| Tab | Feature / Setting | Status | Observation & Technical Explanation |
| :--- | :--- | :--- | :--- |
| **Status** | Connection Interface | ⚠️ Misleading UI | Displays a **"No device detected"** error. **Cause:** The `status` block is pending in the YAML file. Without telemetry data, the GUI triggers a UI fallback, incorrectly acting as if the device is disconnected. |
| **General** | Redirect Audio | ❌ Not Working | Changing this setting had no verifiable effect on the device or OS routing. |
| **Device** | Mic Side Tone | ✅ Working | Responds as expected. |
| **Device** | Noise Cancelling | ✅ Working | ANC modes toggle correctly. |
| **Device** | Noise Level | ✅ Working | ANC/Transparency levels are successfully applied. |
| **Device** | Wear Sense | ⚠️ Desync Issue | Toggling this alters the hardware volume, but the OS sink volume does not sync. **Cause:** Without incoming status updates, the daemon listener cannot trigger `manage_mix_change()`, leaving the volume desynced until manually adjusted. |
| **Device** | Mic Volume | ❌ Not Working | No change detected in the actual audio input level. |
| **Device** | PM Shutdown | ❌ Not Working | Power Management (auto-shutdown) commands have no effect. |
| **Device** | Volume Limiter | ❓ Unverified | Could not verify if the hardware volume limiter became active. |
| **Equalizer** | Preset Control | ⚠️ Logical Bug | Channel EQ presets continue to affect the audio output even when explicitly toggled off in the UI. |