### PR TITLE
feat: add SteelSeries Arctis 9 support

### DIFF
--- a/docs/device_configuration_file_specs.md
+++ b/docs/device_configuration_file_specs.md
@@ -137,6 +137,42 @@ options_mapping: { value: id, label: description } # Depends on options_source. 
 update_sequence: [0x06, 0x37, 'value']             # The setting's command update sequence
 ```
 
+## Multi-byte and transformed setting values
+
+Some legacy devices (e.g. the Arctis 9) encode settings as multi-byte big-endian
+values or apply a non-linear curve to the slider. The following optional fields on
+a `device.settings.[section].[setting]` extend `update_sequence` beyond a single
+`'value'` byte:
+
+```yaml
+# Multi-byte big-endian value with a unit multiplier
+inactive_time:
+  type: slider
+  min: 1
+  max: 90
+  step: 1
+  default: 30
+  value_multiplier: 60                # multiply the slider value before encoding (here: minutes -> seconds)
+  update_sequence: [0x04, 0x00, 'value_hi', 'value_lo']  # big-endian high/low bytes
+  post_update_sequence: [0x90, 0x00] # optional save-to-flash command sent after the main write
+```
+
+- `value_multiplier` (int, default 1): the slider value is multiplied by this before
+  any byte encoding. Useful when the device expects seconds but the UI is in minutes.
+- `'value_hi'` / `'value_lo'` tokens: emit the high or low byte of the (multiplied)
+  value, enabling 16-bit (and larger) big-endian payloads.
+- `value_transform` (string, optional): applies a named non-linear transform to the
+  slider value before encoding. Currently supported:
+  - `log2_sidetone`: reproduces HeadsetControl's Arctis 9 exponential sidetone curve
+    (slider 0..128 -> device bytes 0xc0..0xfd; 0 = off). Needed because the Arctis 9
+    maps sidetone exponentially, so a linear slider feels wrong at the low end.
+- `post_update_sequence` (list, optional): a second HID command sent immediately
+  after the main `update_sequence`. The Arctis 9 requires `[0x90, 0x00]` to persist
+  settings to onboard memory; without it, changes are lost on power-cycle.
+
+These fields are all optional and default to no-op / single-byte behavior, so
+existing device configs are unaffected.
+
 ## YAML's device.status_parse.[status_name] types
 
 Linux Arctis Manager supports out of the box the following status types. Additional types need to be implemented in the code.

--- a/docs/device_support.md
+++ b/docs/device_support.md
@@ -128,3 +128,30 @@ You got the idea. And now go map all the settings! 🙃
 ## Questions? Doubts?
 
 Join the discord channel and discuss together! (see the project's website URL for the invitation).
+
+
+## Note on the Arctis 9 (legacy 31-byte protocol)
+
+The Arctis 9 uses the older 31-byte SteelSeries HID protocol (also used by the
+Arctis 7 / Pro), not the 64-byte Nova protocol. A few specifics worth recording
+for future device authors:
+
+- **Single interface.** Unlike Nova devices, the Arctis 9 exposes only USB
+  interface 0 (EP 0x81 IN, no OUT endpoint). Commands are sent via `SET_REPORT`
+  control transfers (`command_interface_index: [0, 0]`) and status is read from
+  the same interface's IN endpoint (`listen_interface_indexes: [0]`).
+- **Kernel driver detach on interface 0.** Because interface 0 is a standard HID
+  interface, the kernel `usbhid` driver claims it. The LAM `CoreEngine` skips
+  interface 0 by default (Nova devices use a vendor interface instead). LAM now
+  detaches interface 0 when `command_interface_index[0] == 0x00`, i.e. when a
+  legacy device actually uses interface 0 as its control interface. Nova configs
+  are unaffected (the condition is a no-op for them).
+- **Protocol reference.** The byte layout was cross-checked against the
+  HeadsetControl project's `steelseries_arctis_9.hpp` (GPL-3.0), which documents
+  the status request `0x20`, the response prefix `0xaa`, battery byte index 3
+  (range 0x64-0x9a), charging byte 4, sidetone byte 8 (0xc0 off - 0xfd max),
+  and chatmix bytes 9/10 (0-19 each).
+- **No Wireshark required.** The protocol was confirmed with a small pyusb
+  probe on Linux (send `0x20` via `SET_REPORT`, read EP 0x81) rather than a
+  Windows Wireshark capture, since HeadsetControl had already reverse-engineered
+  the device.

--- a/src/linux_arctis_manager/config.py
+++ b/src/linux_arctis_manager/config.py
@@ -70,16 +70,41 @@ class ConfigSetting(JsonSerializable):
         return { **super().to_dict(), **self.get_kwargs() }
 
     def get_update_sequence(self, value: int) -> list[int]:
+        # Support multi-byte big-endian settings via value_hi/value_lo tokens and a
+        # value_multiplier (e.g. Arctis 9 inactive time = minutes*60 as 16-bit seconds).
+        multiplier = getattr(self, 'value_multiplier', 1) or 1
+        v = int(value) * multiplier
+        # value_transform: log2_sidetone reproduces HeadsetControl's Arctis 9
+        # exponential sidetone curve (slider 0..128 -> 0xc0..0xfd).
+        transform = getattr(self, 'value_transform', None)
+        if transform == 'log2_sidetone':
+            import math
+            num = int(value)
+            if num > 0:
+                num = int((math.log2(num) * 100) / 700 * 128) if num > 0 else 0
+                num = max(0x00, min(0x3d, num))   # 0..0x3d maps to 0xc0..0xfd
+                v = 0xc0 + num
+            else:
+                v = 0xc0  # off
         result = []
         for b in self.update_sequence:
             if isinstance(b, int):
                 result.append(b)
             elif b == 'value':
-                result.append(value)
+                result.append(v & 0xff)
+            elif b == 'value_hi':
+                result.append((v >> 8) & 0xff)
+            elif b == 'value_lo':
+                result.append(v & 0xff)
             else:
                 raise Exception(f"Invalid update sequence value: {b}")
 
         return result
+
+    def get_post_update_sequence(self) -> list[int]:
+        # Optional save-to-flash command sent after the main update
+        # (e.g. Arctis 9 uses [0x90, 0x00] to persist settings to onboard memory).
+        return list(getattr(self, 'post_update_sequence', []))
 
     def __getattribute__(self, name: str) -> Any:
         return super().__getattribute__(name)

--- a/src/linux_arctis_manager/core.py
+++ b/src/linux_arctis_manager/core.py
@@ -544,6 +544,10 @@ class CoreEngine:
 
         endpoint = self.get_command_endpoint_address()
         self.send_command(config.get_update_sequence(value), endpoint, self.device_config.command_interface_index[1])
+        # Optional save-to-flash after the main write (e.g. Arctis 9: [0x90, 0x00]).
+        post = config.get_post_update_sequence()
+        if post:
+            self.send_command(post, endpoint, self.device_config.command_interface_index[1])
 
 
     def send_command(self, command: list[int], endpoint: int, control_interface_index: int = 0) -> None:
@@ -591,7 +595,10 @@ class CoreEngine:
 
         interfaces = list(set([config.command_interface_index[0], *config.listen_interface_indexes]))
         for interface in interfaces:
-            if interface == 0x00:
+            # Legacy SteelSeries devices (e.g. Arctis 9) use interface 0 as the control
+            # interface, so usbhid must be detached there too. Nova devices use a vendor
+            # interface and have no kernel driver on 0, so this is a no-op for them.
+            if interface == 0x00 and config.command_interface_index[0] != 0x00:
                 continue
             if usb_device.is_kernel_driver_active(interface):
                 self.logger.info(f"Kernel driver active on interface {interface}, detaching...")
@@ -607,7 +614,7 @@ class CoreEngine:
 
         interfaces = list(set([config.command_interface_index[0], *config.listen_interface_indexes]))
         for interface in interfaces:
-            if interface == 0x00:
+            if interface == 0x00 and config.command_interface_index[0] != 0x00:
                 continue
             if not usb_device.is_kernel_driver_active(interface):
                 self.logger.info(f"Kernel driver inactive on interface {interface}, re-attaching...")

--- a/src/linux_arctis_manager/devices/arctis_9.yaml
+++ b/src/linux_arctis_manager/devices/arctis_9.yaml
@@ -1,0 +1,102 @@
+device:
+  name: SteelSeries Arctis 9
+  vendor_id: 0x1038
+  product_ids:
+    - 0x12c2
+    - 0x12c4
+  command_padding:
+    length: 31
+    position: end
+    filler: 0x00
+
+  # Interface 0 only: EP 0x81 IN + control SET_REPORT (no OUT EP).
+  command_interface_index: [0, 0]
+  listen_interface_indexes: [0]
+
+  device_init:
+    - ['status.request']
+
+  status:
+    request: 0x20
+    response_mapping:
+      - starts_with: 0xaa
+        headset_battery_charge: 0x03
+        cable_charging: 0x04
+        mic_side_tone: 0x08
+        media_mix: 0x09
+        chat_mix: 0x0a
+    representation:
+      headset:
+        - headset_battery_charge
+        - cable_charging
+      microphone:
+        - mic_side_tone
+      mixer:
+        - media_mix
+        - chat_mix
+
+  settings:
+    microphone:
+      mic_side_tone:
+        # HC exponential curve: log2(level)*100 -> 0..128 -> 0xc0..0xfd. Slider 0..128.
+        type: slider
+        min: 0
+        max: 128
+        step: 1
+        default: 0
+        min_label: mic_muted
+        max_label: perc_100
+        value_transform: log2_sidetone
+        update_sequence: [0x06, 0x00, 'value']
+        post_update_sequence: [0x90, 0x00]
+    power_management:
+      inactive_time:
+        # Auto power-off after N minutes of inactivity.
+        # WARNING: 0 = IMMEDIATE shutdown (0 seconds), NOT "never". The Arctis 9
+        # has no known "never" sentinel in the documented protocol (HC caps at 255 min).
+        # min=1 to prevent accidental instant power-off. Max finite = 255 min (4h15m).
+        type: slider
+        min: 1
+        max: 90
+        step: 1
+        default: 30
+        min_label: perc_1
+        max_label: perc_100
+        value_multiplier: 60
+        update_sequence: [0x04, 0x00, 'value_hi', 'value_lo']
+        post_update_sequence: [0x90, 0x00]
+
+    # Verified working: notification sound on/off (beep on connect/disconnect)
+    notification_sound:
+      notification_sound:
+        type: toggle
+        values:
+          off: 0x00
+          on: 0x01
+          off_label: off
+          on_label: on
+        default: 0x01
+        update_sequence: [0x06, 0x51, 'value']
+        post_update_sequence: [0x90, 0x00]
+
+  status_parse:
+    headset_battery_charge:
+      type: percentage
+      perc_min: 0x64
+      perc_max: 0x9a
+    cable_charging:
+      type: on_off
+      on: 0x01
+      off: 0x00
+    mic_side_tone:
+      type: percentage
+      perc_min: 0xc0
+      perc_max: 0xfd
+    media_mix:
+      type: percentage
+      perc_min: 0x00
+      perc_max: 0x13
+    chat_mix:
+      type: percentage
+      perc_min: 0x00
+      perc_max: 0x13


### PR DESCRIPTION
## Summary

Adds support for the **SteelSeries Arctis 9** (USB IDs `1038:12c2` / `1038:12c4`), which uses the legacy 31-byte SteelSeries HID protocol — a single USB interface 0 with no OUT endpoint — rather than the 64-byte Nova protocol used by the currently-supported devices.

This is my first contribution to this project. The device config and code changes were developed and verified on a real Arctis 9 on Arch Linux.

## What's included

### New device config: `arctis_9.yaml`

| Feature | Direction | Notes |
|---|---|---|
| Battery level | read | byte 3, range 0x64–0x9a → 0–100% |
| Charging status | read | byte 4 (0x01 = charging) |
| ChatMix | read | bytes 9/10 (game/chat, 0–19 each) |
| Sidetone | read/write | byte 8, exponential curve (0xc0 off → 0xfd max) |
| Auto-shutoff (inactive time) | write | 1–90 min, encoded as `minutes×60` 16-bit big-endian seconds |
| Notification sound | write | on/off toggle |

All writes are followed by a `[0x90, 0x00]` save command so settings persist to the headset's onboard memory.

### CoreEngine fixes (`core.py`)

1. **Interface 0 kernel driver detach.** The Arctis 9 uses USB interface 0 as its control interface, but `CoreEngine` skipped interface 0 entirely (correct for Nova devices, which use a vendor interface). It now detaches `usbhid` on interface 0 when `command_interface_index[0] == 0x00`. This is a no-op for Nova configs (the condition is false).
2. **`post_update_sequence`.** After sending the main `update_sequence`, the engine sends an optional second command to persist settings to flash.

### Config engine extensions (`config.py`)

All optional, all default to existing single-byte behavior — no existing device config is affected:

- **`value_multiplier`** — scales the slider value before encoding (e.g. minutes → seconds).
- **`'value_hi'` / `'value_lo'` tokens** — emit big-endian multi-byte payloads.
- **`value_transform: log2_sidetone`** — reproduces the Arctis 9's exponential sidetone curve.
- **`post_update_sequence`** — optional save-to-flash command after the main write.

### Docs

- `device_configuration_file_specs.md` — documents the four new settings fields with a worked example.
- `device_support.md` — a note on the Arctis 9's legacy protocol and how it differs from Nova devices.

## How it was reverse-engineered

I did **not** use a Windows Wireshark capture. The protocol was cross-checked against the [HeadsetControl](https://github.com/Sapd/HeadsetControl) project's `steelseries_arctis_9.hpp` (GPL-3.0), which documents the status request byte `0x20`, the `0xaa` response prefix, and the byte indices for battery/charging/sidetone/chatmix. I confirmed the live byte layout with a small pyusb probe on Linux (send `0x20` via `SET_REPORT` on interface 0, read EP 0x81) and verified each writable setting by reading status back before/after.

## How it was tested

All testing was done on **Arch Linux** with a physical SteelSeries Arctis 9 (`1038:12c2`) connected via its 2.4GHz wireless dongle, with the `linux-arctis-manager` AUR package (v2.4.1) as the base.

### USB / HID layer
- `lsusb` confirms the device enumerates as `1038:12c2` + `1038:12c4`.
- A pyusb probe reproduces LAM's exact `SET_REPORT` path (interface 0, `wIndex=0`, 31-byte padded payload) and returns the status frame `aa 01 01 94 00 00 00 00 <sidetone> <game> <chat> …`.

### Daemon
- Before the kernel-detach fix: `CoreEngine: Error sending command: [Errno 16] Resource busy` on every `SET_REPORT` (13000+ log lines), because `usbhid` held interface 0.
- After the fix: `Kernel driver active on interface 0, detaching… / Claimed interface 0`, zero `Resource busy` errors.
- PulseAudio virtual sinks `Arctis_Media` / `Arctis_Chat` created successfully.

### D-Bus interface (end-to-end via `gdbus`)
- `GetStatus` returns: battery 88% (matches `headsetcontrol -b`), charging off, chatmix centered, sidetone reflecting the last write.
- `SetSetting mic_side_tone <v>`: slider 0 → 0% (off, byte 0xc0), 8 → 45%, 32 → 100%, 128 → 100% (byte 0xfd). Matches HeadsetControl's `log2` mapping exactly.
- `SetSetting inactive_time <v>`: 15 / 60 / 90 all return `true`, stored value persists, zero USB errors.
- `SetSetting notification_sound 0` / `1`: both return `true`; an audible beep is heard on toggle (verified by ear).

### Cross-check
- `headsetcontrol -b` reports the same battery percentage as LAM's `GetStatus` (88% at the time of testing), confirming the byte-index mapping is correct.

## What's NOT included (and why)

Based on the official Arctis 9 user manual and SteelSeries Engine 3 documentation:

- **Equalizer** (10-band, persists to headset) — the one genuinely-missing feature. Requires a Windows Wireshark capture of SteelSeries Engine writing the EQ; I don't have that capture. The HID command bytes are unknown.
- **DTS Headphone:X v2** — PC-only software DSP, not a headset setting. Out of scope.
- **LED toggle** — the Arctis 9 has a single status LED (battery-level color: green/yellow/red), not a controllable earcup LED. The Arctis 7's `0x06 0x35` command is silently ignored. Not implemented.
- **Voice prompts** — not a documented Arctis 9 feature; the Arctis 7's `0x06 0x55` command has no effect. Not implemented.
- **Mic volume** — Engine exposes a slider, but it controls the Windows audio mixer level, not a device HID command. Writing `0x06 0x37` had no effect on the headset. Not implemented.
- **"Never" auto-shutoff** — `0` seconds means *immediate* power-off on the Arctis 9 (not "never"). HeadsetControl caps the field at 255 min and offers no disable. No known "never" sentinel; I didn't want to probe blind. The slider minimum is 1 minute.

## Honesty note

The device config and code changes in this PR were developed with the assistance of an AI coding agent (Claude, via the Pi harness). I directed the work, verified every feature physically on my hardware, and wrote this PR description myself. The protocol bytes come from HeadSetControl's GPL-3.0 source and my own USB probing, not from AI guesswork. I've noted above which features I could not verify and deliberately left out.

## Checklist

- [x] Device config follows the [specs](docs/device_configuration_file_specs.md)
- [x] New config fields are optional and backward-compatible
- [x] Tested on real hardware (Arctis 9, Arch Linux, LAM v2.4.1)
- [x] Battery reading cross-checked against `headsetcontrol`
- [x] Docs updated for the new config features
- [ ] Equalizer support (needs Wireshark capture — left for a follow-up)
- [ ] `lam-cli udev write-rules` picks up the new PID automatically (generated from device configs at runtime)

Closes the gap for Arctis 9 owners who currently have no Linux management tool beyond the CLI-only HeadsetControl.
