### PR TITLE
Clear stale Sonar icon during v3 initialization

### DIFF
--- a/daemon/device-configs/base_arctis_nova_pro_wireless.yaml
+++ b/daemon/device-configs/base_arctis_nova_pro_wireless.yaml
@@ -483,7 +483,9 @@ sync_read:
 
 lifecycle:
   init:
-    - call: enable_sonar
+    # LAM does not provide SteelSeries Sonar. Clear a stale station icon while
+    # keeping software ChatMix available independently.
+    - call: disable_sonar
     - call: enable_chatmix
   post_init:
     - call: send_init_wireless_connection_battery_status

--- a/daemon/device-configs/base_arctis_nova_pro_wireless.yaml
+++ b/daemon/device-configs/base_arctis_nova_pro_wireless.yaml
@@ -484,8 +484,10 @@ sync_read:
 lifecycle:
   init:
     # LAM does not provide SteelSeries Sonar. Clear a stale station icon while
-    # keeping software ChatMix available independently.
+    # keeping software ChatMix available independently. Start from the neutral
+    # hardware EQ before persisted LAM settings are re-applied by the daemon.
     - call: disable_sonar
+    - call: reset_eq_preset
     - call: enable_chatmix
   post_init:
     - call: send_init_wireless_connection_battery_status

--- a/daemon/engine/src/device_session.rs
+++ b/daemon/engine/src/device_session.rs
@@ -274,6 +274,11 @@ impl DeviceSession {
                     .await?;
                 Ok(vec![])
             }
+            "reset_eq_preset" => {
+                self.send_api_write("selected_eq_preset", &u8_fields(&[("eq_preset", 0)]))
+                    .await?;
+                Ok(vec![])
+            }
             "enable_chatmix" => {
                 self.send_api_write("software_chatmix_status", &u8_fields(&[("status", 1)]))
                     .await?;
@@ -556,6 +561,42 @@ lifecycle:
         assert_eq!(received[0], 0x06); // report_id constant
         assert_eq!(received[1], 0x09); // command constant
         assert_eq!(&received[2..], &[0u8; 6]);
+    }
+
+    #[tokio::test]
+    async fn reset_eq_preset_lifecycle_selects_flat() {
+        let (engine_fd, peer_fd) = make_pair();
+        let session = DeviceSession::new(
+            cfg(r#"
+structs:
+  selected_eq_preset:
+    - {name: report_id, type: uint8, constant: 0x06}
+    - {name: command,   type: uint8, constant: 0x2E}
+    - {name: eq_preset, type: uint8, range: [0, 18]}
+apis:
+  selected_eq_preset:
+    write: {transport: HID_IO, chunk_size: 8}
+lifecycle:
+  init:
+    - call: reset_eq_preset
+"#),
+            engine_fd,
+        )
+        .expect("from_fd");
+
+        let task = tokio::spawn(async move {
+            let mut s = session;
+            s.device_init().await
+        });
+
+        let mut peer = HidTransport::from_fd(peer_fd).expect("from_fd");
+        let received = peer
+            .read_interrupt(Duration::from_millis(500))
+            .await
+            .expect("engine should have sent the flat preset report");
+
+        task.await.unwrap().unwrap();
+        assert_eq!(&received[..3], &[0x06, 0x2E, 0x00]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Clear the Nova Pro Wireless Sonar station icon during v3 device initialization instead of enabling it unconditionally.

## Reason

Command `06 8d` only controls whether the base station reports Sonar as present. LAM does not provide SteelSeries Sonar, so enabling the icon during startup is misleading.

A USBPcap capture of current SteelSeries GG confirmed that the icon is enabled only when its Sonar software is active. This is independent from ChatMix (`06 49`) and from the hardware EQ preset.

## Testing

Tested on an Arctis Nova Pro Wireless, USB ID `1038:12e0`, with v3 `3.0.0-alpha1`:

- The stale Sonar icon is cleared after daemon startup.
- The hardware EQ remains in PRESET mode.
- The selected hardware preset remains active.
- ChatMix remains enabled at the base station.
- Changing ChatMix on the station continues to update the Linux Media/Chat balance.
- All 350 Rust tests pass.
