### PR TITLE
Add Fedora libudev build dependency

### DIFF
--- a/packaging/containers/fedora.base.dockerfile
+++ b/packaging/containers/fedora.base.dockerfile
@@ -11,6 +11,7 @@ RUN dnf update -y && \
         uv \
         python3 \
         python3-devel \
+        systemd-devel \
         rpm-build \
         rpmdevtools \
         libcap \

--- a/packaging/fedora/linux-arctis-manager.spec
+++ b/packaging/fedora/linux-arctis-manager.spec
@@ -14,6 +14,7 @@ BuildRequires:  cargo
 BuildRequires:  rust
 BuildRequires:  uv
 BuildRequires:  python3
+BuildRequires:  systemd-devel
 BuildRequires:  libcap
 
 Requires:       python3


### PR DESCRIPTION
## Summary

Add Fedora's libudev development package to the v3 container and RPM build dependencies.

## Problem

A clean v3 build on Fedora 44 fails while compiling `libudev-sys`:

```text
Package 'libudev' not found
The system library `libudev` required by crate `libudev-sys` was not found.
The file `libudev.pc` needs to be installed.
```

Both `tokio-udev` and the `linux-native` hidapi backend require libudev at link time. On Fedora, `libudev.pc` is provided by `systemd-devel`, as already noted in `docs/v3-backlog.md`.

## Changes

- Install `systemd-devel` in the Fedora container base image.
- Add `systemd-devel` to the RPM `BuildRequires` list.

## Testing

Reproduced the build failure on Fedora 44 without `systemd-devel`. After installing it, all 350 Rust tests and a fresh optimized `make build` completed successfully.
