### PR TITLE
Make dependency installation hints selectable

### DIFF
--- a/src/linux_arctis_manager/gui/eq_widget.py
+++ b/src/linux_arctis_manager/gui/eq_widget.py
@@ -987,6 +987,10 @@ class QEQWidget(QWidget):
 
         self._ladspa_warn_label = QLabel()
         self._ladspa_warn_label.setWordWrap(True)
+        self._ladspa_warn_label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+            | Qt.TextInteractionFlag.TextSelectableByKeyboard
+        )
         lf_layout.addWidget(self._ladspa_warn_label)
 
         lf_btn_row = QHBoxLayout()

--- a/src/linux_arctis_manager/gui/nc_widget.py
+++ b/src/linux_arctis_manager/gui/nc_widget.py
@@ -102,6 +102,10 @@ class QNCWidget(QWidget):
         self._rnnoise_frame.setLayout(rf_layout)
         self._rnnoise_warn_label = QLabel()
         self._rnnoise_warn_label.setWordWrap(True)
+        self._rnnoise_warn_label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+            | Qt.TextInteractionFlag.TextSelectableByKeyboard
+        )
         rf_layout.addWidget(self._rnnoise_warn_label)
         rf_btn_row = QHBoxLayout()
         self._rnnoise_retry_btn = QPushButton(I18n.translate('ui', 'nc_retry'))
@@ -170,6 +174,10 @@ class QNCWidget(QWidget):
         self._swh_frame.setLayout(swh_layout)
         self._swh_warn_label = QLabel()
         self._swh_warn_label.setWordWrap(True)
+        self._swh_warn_label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+            | Qt.TextInteractionFlag.TextSelectableByKeyboard
+        )
         swh_layout.addWidget(self._swh_warn_label)
         swh_retry_row = QHBoxLayout()
         swh_retry_btn = QPushButton(I18n.translate('ui', 'nc_retry'))


### PR DESCRIPTION
## Summary

Make the dependency installation hints in the software EQ and microphone noise-cancelling panels selectable with both mouse and keyboard.

## Motivation

These labels contain distribution-specific package installation commands. Currently users have to retype those commands manually from the GUI. Allowing text selection makes the existing instructions directly copyable without changing their layout or wording.

## Changes

- Enable mouse and keyboard text selection for the LADSPA SWH warning label.
- Enable mouse and keyboard text selection for the RNNoise and SWH microphone warning labels.

## Verification

- `git diff --check`
- Python compilation of both modified modules
- Manually tested in the v3 GUI on Fedora/KDE
