### PR TITLE
Fix Nova Pro muted mic brightness value range

### DIFF
--- a/daemon/device-configs/base_arctis_nova_pro_wireless.yaml
+++ b/daemon/device-configs/base_arctis_nova_pro_wireless.yaml
@@ -425,7 +425,7 @@ sync_events:
   0xBF:
     emit: muted_mic_brightness_changed
     fields:
-      - {name: muted_mic_brightness, byte: 2, transform: mic_vol_to_percent, display_type: percentage}
+      - {name: muted_mic_brightness, byte: 2}
     side_effects:
       - call: sync_all
 
@@ -466,7 +466,7 @@ sync_read:
     maps:
       - {emit: bluetooth_startup_changed,       field: bt_power_default,         display_type: on_off}
       - {emit: bt_call_default_changed,          field: bt_call_default}
-      - {emit: muted_mic_brightness_changed,     field: muted_mic_brightness,     transform: mic_vol_to_percent, display_type: percentage}
+      - {emit: muted_mic_brightness_changed,     field: muted_mic_brightness}
       - {emit: power_inactivity_timer_changed,   field: power_inactivity_timer,   transform: timer_enum_to_minutes}
       - {emit: wireless_mode_changed,            field: wireless_mode}
       - {emit: wireless_connection_changed,      field: radio_connection_status,  transform: radio_connection_to_label}


### PR DESCRIPTION
## Summary

Preserve the Nova Pro Wireless `muted_mic_brightness` value as the hardware's native `1..10` setting instead of converting it to a percentage.

## Problem

The field is declared with a range of `1..10`, but its status mappings currently apply `mic_vol_to_percent` and label the result as a percentage. This makes a hardware value such as `1` appear as `10%` and causes the UI/status representation to disagree with the actual station setting.

## Changes

- Remove `mic_vol_to_percent` from the live brightness event.
- Remove the percentage transform and display type from the synchronized status mapping.
- Keep the existing native `1..10` field range unchanged.

## Verification

- YAML parses successfully.
- `git diff --check`
- Manually tested with the muted microphone brightness set to `1`; it remains and is reported as `1` instead of becoming `10%`.
